### PR TITLE
ohmyzsh/templates/zshrc.j2: fix PATH scripts being found in bash but not zsh

### DIFF
--- a/roles/ohmyzsh/templates/zshrc.j2
+++ b/roles/ohmyzsh/templates/zshrc.j2
@@ -81,10 +81,10 @@ alias lsn="ls -l | awk '{k=0;for(i=0;i<=8;i++)k+=((substr(\$1,i+2,1)~/[rwx]/) \
              *2^(8-i));if(k)printf(\"%0o \",k);print}'"
 
 # tools
-export PATH=$PATH:~/tools/bin
+export PATH="$PATH":~/tools/bin
 
 # tools
-export PATH=$PATH:~/.local/bin
+export PATH="$PATH":~/.local/bin
 
 if [ -e ~/.nix-profile/etc/profile.d/nix.sh ]; then
   source ~/.nix-profile/etc/profile.d/nix.sh


### PR DESCRIPTION
After configuration markdown.sh script was available from PATH in bash but not zsh. Quick google search pointed to the underlying issue.

https://apple.stackexchange.com/questions/434805/zsh-does-not-find-script-in-path-while-bash-does-echo-path-is-the-same