### PR TITLE
roles/packages_base/tasks/main.yml: fix for failed RPM Fusion and ffmpeg install

### DIFF
--- a/roles/packages_base/tasks/main.yml
+++ b/roles/packages_base/tasks/main.yml
@@ -54,6 +54,28 @@
       cat /sys/kernel/debug/dri/0/i915_gpu_info | grep "graphics version" | cut -d ' ' -f 3
     fi
   register: gpu_gen
+  
+- name: Install RPM Fusion GPG keys (for Intel CPUs 7th or older generations)
+  become: true
+  dnf:
+    name:
+      - distribution-gpg-keys
+    state: present
+  when: (gpu_gen.stdout | int) <= 7
+
+- name: Import RPM Fusion free GPG keys (for Intel CPUs 7th or older generations)
+  become: true
+  rpm_key:
+    state: present
+    key: /usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-{{ ansible_distribution_major_version }}
+  when: (gpu_gen.stdout | int) <= 7
+  
+- name: Import RPM Fusion nonfree GPG keys (for Intel CPUs 7th or older generations)
+  become: true
+  rpm_key:
+    state: present
+    key: /usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-{{ ansible_distribution_major_version }}
+  when: (gpu_gen.stdout | int) <= 7
 
 - name: Install RPM Fusion repositories (for Intel CPUs 7th or older generations)
   become: true
@@ -69,6 +91,7 @@
   dnf:
     name: ffmpeg
     state: present
+    allowerasing: true
     disablerepo: ffmpeg-free
   when: (gpu_gen.stdout | int) <= 7
 


### PR DESCRIPTION
fix for failed RPM Fusion install:
```
TASK [packages_base : Install RPM Fusion repositories (for Intel CPUs 7th or older generations)] ***
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for rpmfusion-free-release-38-1.noarch: Public key for rpmfusion-free-release-38.noarchmft7jvbw.rpm is not installed"}
```
Added tasks to install distribution-gpg-keys and import both rpmfusion-free and non-free GPG keys

also fixed failed install of ffmpeg:
```
TASK [packages_base : Swap ffmpeg-free with ffmpeg (for Intel CPUs 7th or older generations)] ***
fatal: [127.0.0.1]: FAILED! => {"changed": false, "failures": [], "msg": "Depsolve Error occurred: \n Problem: problem with installed package libswscale-free-6.0-4.fc38.x86_64\n  - package ffmpeg-libs-6.0-6.fc38.x86_64 from rpmfusion-free conflicts with libswscale-free provided by libswscale-free-6.0-4.fc38.x86_64 from @System\n  - package ffmpeg-libs-6.0-6.fc38.x86_64 from rpmfusion-free conflicts with libswscale-free provided by libswscale-free-6.0-2.fc38.x86_64 from fedora\n  - package ffmpeg-libs-6.0-6.fc38.x86_64 from rpmfusion-free conflicts with libswscale-free provided by libswscale-free-6.0-4.fc38.x86_64 from updates\n  - package ffmpeg-6.0-6.fc38.x86_64 from rpmfusion-free requires ffmpeg-libs(x86-64) = 6.0-6.fc38, but none of the providers can be installed\n  - conflicting requests\n  - package ffmpeg-6.0-11.fc38.x86_64 from rpmfusion-free-updates requires ffmpeg-libs(x86-64) = 6.0-11.fc38, but none of the providers can be installed\n  - package ffmpeg-libs-6.0-11.fc38.x86_64 from rpmfusion-free-updates conflicts with libswscale-free provided by libswscale-free-6.0-4.fc38.x86_64 from @System\n  - package ffmpeg-libs-6.0-11.fc38.x86_64 from rpmfusion-free-updates conflicts with libswscale-free provided by libswscale-free-6.0-2.fc38.x86_64 from fedora\n  - package ffmpeg-libs-6.0-11.fc38.x86_64 from rpmfusion-free-updates conflicts with libswscale-free provided by libswscale-free-6.0-4.fc38.x86_64 from updates", "rc": 1, "results": []}
```
I added allowerasing parameter to this task.

Manual way to fix those errors:
```
sudo dnf install distribution-gpg-keys
sudo rpmkeys --import /usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-38
sudo rpmkeys --import /usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-38
sudo dnf install ffmpeg --allowerasing
```