### PR TITLE
roles/packages_base/tasks/main.yml: add neovim

### DIFF
--- a/roles/packages_base/tasks/main.yml
+++ b/roles/packages_base/tasks/main.yml
@@ -16,6 +16,7 @@
       - pre-commit
       - util-linux-user
       - openssl
+      - neovim
     state: latest
 
 - name: Create ~/.local/bin directory if it does not exist


### PR DESCRIPTION
Add neovim package to be installed. It wasn't installed by default on my workstation and it's set as default editor in     roles/ohmyzsh/tasks/main.yml.
ohmyzsh task also sets vim as alias to nvim.