### PR TITLE
bootstrap.sh: install geerlingguy.docker role

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 sudo dnf install ansible
-ansible-galaxy install geerlingguy.docker
+ansible-galaxy role install geerlingguy.docker


### PR DESCRIPTION
This role is an external role to workstation-config repo, so it should be installed before running any playbook from the repo.

Otherwise following error may occur:
```bash
ERROR! the role 'geerlingguy.docker' was not found in /home/user/workstation-config/roles:/home/user/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/home/user/workstation-config

The error appears to be in '/home/user/workstation-config/workstation-setup-eft.yml': line 12, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    - uefitool
    - role:  geerlingguy.docker
      ^ here
```

Refs:
https://galaxy.ansible.com/ui/standalone/roles/geerlingguy/docker/install/