### PR TITLE
git: Safer push & recurse submodules

### DIFF
--- a/roles/git/templates/gitconfig.j2
+++ b/roles/git/templates/gitconfig.j2
@@ -53,8 +53,11 @@
 [sendemail]
 	smtpserver = /usr/bin/msmtp
 [push]
-	default = matching
+	default = simple
+	autoSetupRemote = true
 [gpg]
 	program = gpg
 [commit]
 	gpgsign = true
+[submodule]
+	recurse = true


### PR DESCRIPTION
Change push from `default = matching` to `simple` as `matching` will push multiple branches instead of current one.
It can lead to easily missed errors especially when force pushing. `simple` is safer default option especially for people with less experience and has been default in Git since version 2.0 (10 years) so most people probably won't be expecting current behaviour.

```
[submodule]
    recurse = true
```

This part will automatically recurse most git commands into submodules (e.g. `pull` & `checkout` but not `clone`).
Problems with submodules should be found faster if everyone always uses current commit.